### PR TITLE
Fixed client crash when booting into a map using the +map command line parameter

### DIFF
--- a/game/client/ofd/of_discordrpc.cpp
+++ b/game/client/ofd/of_discordrpc.cpp
@@ -131,8 +131,8 @@ void CTFDiscordRPC::SetLogo( void )
 	const char *pszGameType = "";
 	const char *pszImageLarge = "ico";
 	
-	if ( engine->IsConnected() )
-	{
+	if ( TFGameRules( ) && engine->IsConnected() )
+	{	
 		if (TFGameRules()->GetGameType() == TF_GAMETYPE_UNDEFINED)
 		{
 			pszGameType = "";


### PR DESCRIPTION
It was caused by Discord RPC not verifying that gamerules are valid